### PR TITLE
use config dir under /

### DIFF
--- a/combustion
+++ b/combustion
@@ -50,6 +50,19 @@ if [ "${1-}" = "--prepare" ]; then
                 config_drive_found=1
 	done
 
+  # Check if a directory was dropped in the /sysroot
+	for label in combustion COMBUSTION ignition IGNITION; do
+		[ "${config_drive_found}" = "1" ] && break
+		[ -e "/sysroot/${label}" ] || continue
+
+		if ! mount -o bind /$sysroot/{label} "${config_mount}"; then
+			echo "Failed to bind mount existing config"
+			exit 1
+		fi
+
+                config_drive_found=1
+	done
+
 	if [ "${config_drive_found}" = "0" ]; then
 		echo "No config drive found"
 		exit 0

--- a/combustion
+++ b/combustion
@@ -37,6 +37,19 @@ if [ "${1-}" = "--prepare" ]; then
                 config_drive_found=1
 	done
 
+  # Check if a directory was dropped in the initrd
+	for label in combustion COMBUSTION ignition IGNITION; do
+		[ "${config_drive_found}" = "1" ] && break
+		[ -e "/${label}" ] || continue
+
+		if ! mount -o bind /${label} "${config_mount}"; then
+			echo "Failed to bind mount existing config"
+			exit 1
+		fi
+
+                config_drive_found=1
+	done
+
 	if [ "${config_drive_found}" = "0" ]; then
 		echo "No config drive found"
 		exit 0


### PR DESCRIPTION
Check the /-dir for combustion labels and if exists create a bind
mount. Useful if ALP was booted in a initrd.
