### PR TITLE
combustion.rules: Match /module/qemu_fw_cfg instead of the namespace within

### DIFF
--- a/combustion.rules
+++ b/combustion.rules
@@ -14,7 +14,9 @@ ACTION=="add", SUBSYSTEM=="block", ENV{ID_FS_LABEL}=="COMBUSTION", ENV{SYSTEMD_A
 ACTION=="add", SUBSYSTEM=="block", ENV{ID_FS_LABEL}=="ignition", ENV{SYSTEMD_ALIAS}+="/dev/combustion/config"
 ACTION=="add", SUBSYSTEM=="block", ENV{ID_FS_LABEL}=="IGNITION", ENV{SYSTEMD_ALIAS}+="/dev/combustion/config"
 # QEMU fw_cfg blob with key opt/org.opensuse.combustion
-ACTION=="add", SUBSYSTEM=="opt", ENV{DEVPATH}=="/firmware/qemu_fw_cfg/by_name/opt/org.opensuse.combustion", ENV{SYSTEMD_ALIAS}+="/dev/combustion/config", TAG+="systemd"
+# There are add events for keys inside fw_cfg, but they are unreliable: https://github.com/systemd/systemd/issues/28638
+# Using the platform device with add|bind does not work with TAG+="systemd" for some reason, so use the module...
+ACTION=="add", SUBSYSTEM=="module", KERNEL=="qemu_fw_cfg", TEST=="/sys/firmware/qemu_fw_cfg/by_name/opt/org.opensuse.combustion", ENV{SYSTEMD_ALIAS}+="/dev/combustion/config", TAG+="systemd"
 
 # If combustion won't run, alias it to /dev/null to avoid waiting
 ACTION=="add", SUBSYSTEM=="mem", ENV{DEVPATH}=="/devices/virtual/mem/null", GOTO="combustion_dev_null"


### PR DESCRIPTION
During boot, dev-combustion-config.device did not appear even though the fwcfg key was there. There appears to be some mismatch between what hotplug and coldplug count as devices, which makes the fwcfg key unusable for this case. Due to a different bug(?) the platform device triggers the rules but the systemd tag has no effect. As a workaround, use the module add event as trigger and check for existence of the key in sysfs. This is reliable enough as the module registers the sysfs contents synchonously.