### PR TITLE
New module to handle firstboot detection in the initrd

### DIFF
--- a/30firstboot/firstboot-detect
+++ b/30firstboot/firstboot-detect
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eu
+what=$(systemctl show -P What sysroot.mount)
+opts=$(systemctl show -P Options sysroot.mount)
+mount -o "$opts" "$what" /sysroot
+
+# Handle x-initrd.mount without initrd-parse-etc.service
+awk '$4 ~ /x-initrd.mount/ { if(system("mount --target-prefix /sysroot --fstab /sysroot/etc/fstab " $2) != 0) exit 1; }' /sysroot/etc/fstab
+
+if [ -e /sysroot/var/lib/YaST2/reconfig_system ] || ! [ -e /sysroot/etc/machine-id ] \
+	|| grep -qw 'ignition\.firstboot' /proc/cmdline || grep -qw 'combustion\.firstboot' /proc/cmdline; then
+	echo "Firstboot detected"
+	# Make initrd.target require firstboot.target
+	systemctl enable --quiet firstboot.target
+	# As initrd.target/start was already scheduled, ^ does not have any immediate effect.
+	# Triggering a start of initrd.target again schedules the missing jobs.
+	# With --job-mode=fail this fails if any of those missing jobs is destructive, likely
+	# caused by dep cycles in firstboot units.
+	systemctl start --now --no-block --job-mode=fail initrd.target
+fi

--- a/30firstboot/firstboot-detect.service
+++ b/30firstboot/firstboot-detect.service
@@ -1,0 +1,33 @@
+[Unit]
+Description=Detect Firstboot
+DefaultDependencies=no
+
+# This needs /sysroot to be mountable
+# Should also include systemd-fsck-root, but that would create a cycle
+# with dracut-initqueue below.
+Requires=initrd-root-device.target
+After=initrd-root-device.target
+
+# But before it's actually mounted
+Before=sysroot.mount
+
+# Combustion/ignition may configure networking, which runs during
+# the initqueue (wicked) or has its own service (NM)
+Before=dracut-initqueue.service nm-initrd.service
+
+# Make sure this is stopped before switch root or emergency:
+# https://github.com/systemd/systemd/issues/3436
+Conflicts=initrd-switch-root.target umount.target
+Conflicts=dracut-emergency.service emergency.service emergency.target
+
+[Service]
+Type=oneshot
+# This has to mount /sysroot as /sysroot, but starting sysroot.mount would
+# screw up ordering
+PrivateMounts=true
+# Work around https://github.com/systemd/systemd/issues/28723
+TemporaryFileSystem=/run/mount
+ExecStart=/usr/bin/firstboot-detect
+
+[Install]
+RequiredBy=initrd.target

--- a/30firstboot/firstboot.target
+++ b/30firstboot/firstboot.target
@@ -1,0 +1,10 @@
+[Unit]
+Description=Initrd Firstboot
+
+# Make sure this is stopped before switch root or emergency:
+# https://github.com/systemd/systemd/issues/3436
+Conflicts=initrd-switch-root.target umount.target
+Conflicts=dracut-emergency.service emergency.service emergency.target
+
+[Install]
+RequiredBy=initrd.target

--- a/30firstboot/module-setup.sh
+++ b/30firstboot/module-setup.sh
@@ -1,0 +1,20 @@
+check() {
+	# Pulled in by other modules only
+	return 255
+}
+
+depends() {
+	echo bash systemd
+}
+
+install() {
+	inst_simple "${moddir}/firstboot-detect.service" "${systemdsystemunitdir}/firstboot-detect.service"
+	inst_simple "${moddir}/firstboot.target" "${systemdsystemunitdir}/firstboot.target"
+	inst_simple "${moddir}/firstboot-detect" "/usr/bin/firstboot-detect"
+	$SYSTEMCTL -q --root "$initdir" enable firstboot-detect.service
+	inst_multiple awk grep mount
+
+	# Work around https://github.com/systemd/systemd/pull/28718
+	mkdir -p "${initdir}/${systemdsystemunitdir}/initrd-parse-etc.service.d/"
+	echo -e "[Unit]\nConflicts=emergency.target" > "${initdir}/${systemdsystemunitdir}/initrd-parse-etc.service.d/emergency.conf"
+}

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,19 @@
+FB_MODULEDIR ?= $(DESTDIR)/usr/lib/dracut/modules.d/30firstboot
 MODULEDIR ?= $(DESTDIR)/usr/lib/dracut/modules.d/35combustion
 
 all:
 
-install:
+install-30firstboot:
+	install -Dm0644 30firstboot/module-setup.sh $(FB_MODULEDIR)/module-setup.sh
+	install -Dm0644 30firstboot/firstboot.target $(FB_MODULEDIR)/firstboot.target
+	install -Dm0755 30firstboot/firstboot-detect $(FB_MODULEDIR)/firstboot-detect
+	install -Dm0644 30firstboot/firstboot-detect.service $(FB_MODULEDIR)/firstboot-detect.service
+
+install: install-30firstboot
 	install -Dm0644 module-setup.sh $(MODULEDIR)/module-setup.sh
 	install -Dm0644 combustion.service $(MODULEDIR)/combustion.service
 	install -Dm0644 combustion-prepare.service $(MODULEDIR)/combustion-prepare.service
 	install -Dm0755 combustion $(MODULEDIR)/combustion
 	install -Dm0644 combustion.rules $(MODULEDIR)/combustion.rules
+
+.PHONY: all install install-30firstboot

--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ subsequent boots.
 
 ### Combustion
 
+The `combustion` dracut module is included by default, but omitted if dracut is
+run on an already configured system in `hostonly` mode.
+
 `firstboot.target` pulls in `combustion.service` and
 `combustion-prepare.service`. The latter runs after the config drive or
 QEMU fw_cfg blob appears (see `combustion.rules` for details). The combustion

--- a/combustion
+++ b/combustion
@@ -98,6 +98,15 @@ EOF
 	exit 0
 fi
 
+# Set by combustion.service but not ignition-kargs-helper.
+# Controls whether config is actually completed by this step,
+# triggering deletion of /var/lib/YaST2/reconfig_system
+complete=0
+
+if [ "${1-}" = "--complete" ]; then
+	complete=1
+fi
+
 delete_resolv_conf=0
 
 cleanup() {
@@ -208,6 +217,8 @@ else
 	chroot /sysroot snapper --no-dbus create -d "After combustion configuration" || :
 fi
 
-rm -f /sysroot/var/lib/YaST2/reconfig_system
+if [ "${complete}" -eq 1 ]; then
+	rm -f /sysroot/var/lib/YaST2/reconfig_system
+fi
 
 exit 0

--- a/combustion-prepare.service
+++ b/combustion-prepare.service
@@ -2,11 +2,6 @@
 Description=Combustion (preparations)
 DefaultDependencies=false
 
-# Systemd evaluates Requires/After before conditions, so this unit is pulled in
-# even when combustion.service won't run.
-ConditionKernelCommandLine=|ignition.firstboot
-ConditionKernelCommandLine=|combustion.firstboot
-
 # Config drive has to be available
 Wants=dev-combustion-config.device
 After=dev-combustion-config.device

--- a/combustion.rules
+++ b/combustion.rules
@@ -1,11 +1,8 @@
 # SPDX-FileCopyrightText: 2020 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-# These rules are needed to work around two systemd limitations:
-# - It's not possible to wait for one of multiple devices to appear 
-# - ConditionKernelCommandLine is evaluated after Wants/After,
-#   so it waits for the devices unnecessarily
-# Introduce a dev-combustion-config.device unit as alias to the actual device(s).
+# It's not possible to wait for one of multiple devices to appear, so
+# introduce a dev-combustion-config.device unit as alias to the actual device(s).
 # This is only used for the .service dependencies.
 
 # Filesystems with either combustion or ignition as label
@@ -17,15 +14,3 @@ ACTION=="add", SUBSYSTEM=="block", ENV{ID_FS_LABEL}=="IGNITION", ENV{SYSTEMD_ALI
 # There are add events for keys inside fw_cfg, but they are unreliable: https://github.com/systemd/systemd/issues/28638
 # Using the platform device with add|bind does not work with TAG+="systemd" for some reason, so use the module...
 ACTION=="add", SUBSYSTEM=="module", KERNEL=="qemu_fw_cfg", TEST=="/sys/firmware/qemu_fw_cfg/by_name/opt/org.opensuse.combustion", ENV{SYSTEMD_ALIAS}+="/dev/combustion/config", TAG+="systemd"
-
-# If combustion won't run, alias it to /dev/null to avoid waiting
-ACTION=="add", SUBSYSTEM=="mem", ENV{DEVPATH}=="/devices/virtual/mem/null", GOTO="combustion_dev_null"
-GOTO="combustion_end"
-
-LABEL="combustion_dev_null"
-# IMPORT has to be on its own as it returns success or not, even with "="...
-IMPORT{cmdline}="ignition.firstboot"
-IMPORT{cmdline}="combustion.firstboot"
-ENV{ignition.firstboot}!="1", ENV{combustion.firstboot}!="1", ENV{SYSTEMD_ALIAS}+="/dev/combustion/config", TAG+="systemd"
-
-LABEL="combustion_end"

--- a/combustion.service
+++ b/combustion.service
@@ -28,7 +28,7 @@ Conflicts=dracut-emergency.service emergency.service emergency.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/combustion
+ExecStart=/usr/bin/combustion --complete
 
 [Install]
 RequiredBy=firstboot.target

--- a/combustion.service
+++ b/combustion.service
@@ -2,9 +2,6 @@
 Description=Combustion
 DefaultDependencies=false
 
-ConditionKernelCommandLine=|ignition.firstboot
-ConditionKernelCommandLine=|combustion.firstboot
-
 # /sysroot needs to be available, but it's temporarily stopped
 # for remounting so a direct requirement is not possible
 Requires=initrd-root-device.target
@@ -23,6 +20,9 @@ After=ignition-complete.target
 # So that /etc/fstab's x-initrd.mount entries are read (again) later
 Before=initrd-parse-etc.service
 
+# Without DefaultDependencies the target would be reached without us
+Before=firstboot.target
+
 Conflicts=initrd-switch-root.target umount.target
 Conflicts=dracut-emergency.service emergency.service emergency.target
 
@@ -31,4 +31,4 @@ Type=oneshot
 ExecStart=/usr/bin/combustion
 
 [Install]
-RequiredBy=initrd.target
+RequiredBy=firstboot.target

--- a/module-setup.sh
+++ b/module-setup.sh
@@ -1,5 +1,5 @@
 depends() {
-	echo bash network systemd url-lib
+	echo bash firstboot network systemd url-lib
 }
 
 install() {
@@ -15,10 +15,6 @@ install() {
 	# mounts/umounts done by combustion. Just let combustion do it instead.
 	mkdir -p "${initdir}/${systemdsystemunitdir}/ignition-mount.service.d/"
 	echo -e "[Service]\nExecStop=" > "${initdir}/${systemdsystemunitdir}/ignition-mount.service.d/noexecstop.conf"
-
-	# Work around https://github.com/systemd/systemd/pull/28718
-	mkdir -p "${initdir}/${systemdsystemunitdir}/initrd-parse-etc.service.d/"
-	echo -e "[Unit]\nConflicts=emergency.target" > "${initdir}/${systemdsystemunitdir}/initrd-parse-etc.service.d/emergency.conf"
 
 	# Wait up to 10s (30s on aarch64) for the config drive
 	devtimeout=10

--- a/module-setup.sh
+++ b/module-setup.sh
@@ -22,12 +22,6 @@ install() {
 	mkdir -p "${initdir}/etc/modprobe.d"
 	echo "options dasd_mod dasd=autodetect" > "${initdir}/etc/modprobe.d/dasd-autodetect.conf"
 
-	# ignition-mount.service mounts stuff below /sysroot in ExecStart and umounts
-	# it on ExecStop, failing if umounting fails. This conflicts with the
-	# mounts/umounts done by combustion. Just let combustion do it instead.
-	mkdir -p "${initdir}/${systemdsystemunitdir}/ignition-mount.service.d/"
-	echo -e "[Service]\nExecStop=" > "${initdir}/${systemdsystemunitdir}/ignition-mount.service.d/noexecstop.conf"
-
 	# Wait up to 10s (30s on aarch64) for the config drive
 	devtimeout=10
 	[ "$(uname -m)" = "aarch64" ] && devtimeout=30

--- a/module-setup.sh
+++ b/module-setup.sh
@@ -1,3 +1,11 @@
+check() {
+	# Omit if building for this already configured system
+	if [[ $hostonly ]] && [ -e /etc/machine-id ] && ! [ -e /var/lib/YaST2/reconfig_system ]; then
+		return 255
+	fi
+	return 0
+}
+
 depends() {
 	echo bash firstboot network systemd url-lib
 }

--- a/module-setup.sh
+++ b/module-setup.sh
@@ -18,6 +18,10 @@ install() {
 	inst_multiple awk chroot findmnt grep rmdir
 	inst_simple "${moddir}/combustion" "/usr/bin/combustion"
 
+	# Autodetect dasd devices on s390x to discover the config drive
+	mkdir -p "${initdir}/etc/modprobe.d"
+	echo "options dasd_mod dasd=autodetect" > "${initdir}/etc/modprobe.d/dasd-autodetect.conf"
+
 	# ignition-mount.service mounts stuff below /sysroot in ExecStart and umounts
 	# it on ExecStop, failing if umounting fails. This conflicts with the
 	# mounts/umounts done by combustion. Just let combustion do it instead.


### PR DESCRIPTION
Look at /etc/machine-id in the /sysroot, similar to what ConditionFirstBoot in
the real root would do. If firstboot is detected, start firstboot.target.

TODO:
- [x] Import better `x-initrd.mount` handling into `firstboot-detect`
- [x] Remove 755 on firstboot-detect.sh
- [x]  Only install the combustion module if no /etc/machine-id on the host
- [x] Adjust README.md
- [x] Make ignition use this, or at least compatible. Currently there's an ordering dep between ignition-fetch.service/network.target/firstboot-detect.service