### PR TITLE
Don't consider /var/lib/YaST2/reconfig_system for firstboot detection 

### DIFF
--- a/30firstboot/firstboot-detect
+++ b/30firstboot/firstboot-detect
@@ -5,7 +5,7 @@ opts=$(systemctl show -P Options sysroot.mount)
 mount -o "$opts" "$what" /sysroot
 
 # Handle x-initrd.mount without initrd-parse-etc.service
-awk '$4 ~ /x-initrd.mount/ { if(system("mount --target-prefix /sysroot --fstab /sysroot/etc/fstab " $2) != 0) exit 1; }' /sysroot/etc/fstab
+awk '$1 !~ /^#/ && $4 ~ /(\<|,)x-initrd\.mount(\>|,)/ { if(system("mount --target-prefix /sysroot --fstab /sysroot/etc/fstab " $2) != 0) exit 1; }' /sysroot/etc/fstab
 
 if [ -e /sysroot/var/lib/YaST2/reconfig_system ] || ! [ -e /sysroot/etc/machine-id ] \
 	|| grep -qw 'ignition\.firstboot' /proc/cmdline || grep -qw 'combustion\.firstboot' /proc/cmdline; then

--- a/30firstboot/firstboot-detect
+++ b/30firstboot/firstboot-detect
@@ -7,7 +7,7 @@ mount -o "$opts" "$what" /sysroot
 # Handle x-initrd.mount without initrd-parse-etc.service
 awk '$1 !~ /^#/ && $4 ~ /(\<|,)x-initrd\.mount(\>|,)/ { if(system("mount --target-prefix /sysroot --fstab /sysroot/etc/fstab " $2) != 0) exit 1; }' /sysroot/etc/fstab
 
-if [ -e /sysroot/var/lib/YaST2/reconfig_system ] || ! [ -e /sysroot/etc/machine-id ] \
+if ! [ -e /sysroot/etc/machine-id ] \
 	|| grep -qw 'ignition\.firstboot' /proc/cmdline || grep -qw 'combustion\.firstboot' /proc/cmdline; then
 	echo "Firstboot detected"
 	# Make initrd.target require firstboot.target

--- a/README.md
+++ b/README.md
@@ -153,8 +153,9 @@ dependencies out of order). It then checks for the following conditions:
 
 * `combustion.firstboot` or `ignition.firstboot` are present on the kernel
 cmdline
-* `/etc/machine-id` does not exist in `/sysroot`
-* `/var/lib/YaST2/reconfig_system` exists in `/sysroot`
+* `/etc/machine-id` does not exist in `/sysroot`. Note: Unlike systemd's
+`ConditionFirstBoot`, this is not triggered by "uninitialized" in the
+machine-id file or influcenced by `systemd.firstboot=` on the kernel cmdline.
 
 If one of them applies, it enables and starts `firstboot.target`. It's
 important that all units started by `firstboot.target` are effectively

--- a/module-setup.sh
+++ b/module-setup.sh
@@ -1,6 +1,6 @@
 check() {
 	# Omit if building for this already configured system
-	if [[ $hostonly ]] && [ -e /etc/machine-id ] && ! [ -e /var/lib/YaST2/reconfig_system ]; then
+	if [[ $hostonly ]] && [ -e /etc/machine-id ]; then
 		return 255
 	fi
 	return 0


### PR DESCRIPTION
This location isn't accessible in the transactional-update environment and
thus the firstboot modules would be missing in initrds on MicroOS in the case
that /etc/machine-id exists but reconfig_system was touched.

So just don't bother. "dracut -f --no-hostonly" and deleting /etc/machine-id
are valid options already to trigger inclusion.

Also use the improved version of the `x-initrd.mount` code in firstboot-detect.