### PR TITLE
Only attempt firstboot check on devices

### DIFF
--- a/30firstboot/firstboot-detect
+++ b/30firstboot/firstboot-detect
@@ -1,7 +1,15 @@
 #!/bin/sh
 set -eu
-what=$(systemctl show -P What sysroot.mount)
-opts=$(systemctl show -P Options sysroot.mount)
+what="$(systemctl show -P What sysroot.mount)"
+opts="$(systemctl show -P Options sysroot.mount)"
+
+# Catch cases where sysroot isn't a device,
+# especially kiwi's install:CDLABEL=INSTALL syntax.
+if ! echo "$what" | grep -q ^/; then
+	echo "Unable to detect firstboot on $what" >&2
+	exit 0
+fi
+
 mount -o "$opts" "$what" /sysroot
 
 # Handle x-initrd.mount without initrd-parse-etc.service

--- a/combustion-prepare.service
+++ b/combustion-prepare.service
@@ -11,6 +11,10 @@ After=dev-combustion-config.device
 # device
 After=ignition-setup-user.service
 
+# This may enable network services in the same way, so make sure the prepare
+# script could write configiguration before networking is enabled.
+Before=ignition-enable-network.service
+
 # This reconfigures networking, which runs during the initqueue (wicked)
 # or has its own service (NM)
 Before=dracut-initqueue.service nm-initrd.service

--- a/module-setup.sh
+++ b/module-setup.sh
@@ -22,6 +22,12 @@ install() {
 	mkdir -p "${initdir}/etc/modprobe.d"
 	echo "options dasd_mod dasd=autodetect" > "${initdir}/etc/modprobe.d/dasd-autodetect.conf"
 
+	# ignition-mount.service mounts stuff below /sysroot in ExecStart and umounts
+	# it on ExecStop, failing if umounting fails. This conflicts with the
+	# mounts/umounts done by combustion. Just let combustion do it instead.
+	mkdir -p "${initdir}/${systemdsystemunitdir}/ignition-mount.service.d/"
+	echo -e "[Service]\nExecStop=" > "${initdir}/${systemdsystemunitdir}/ignition-mount.service.d/noexecstop.conf"
+
 	# Wait up to 10s (30s on aarch64) for the config drive
 	devtimeout=10
 	[ "$(uname -m)" = "aarch64" ] && devtimeout=30


### PR DESCRIPTION
Otherwise firstboot-detect attempts to mount the kiwi dump source device.