### PR TITLE
Fix failure if /sysroot not mounted and no config provided

### DIFF
--- a/combustion
+++ b/combustion
@@ -116,16 +116,18 @@ cleanup() {
         	rm -f /sysroot/etc/resolv.conf || true
 	fi
 
-	# umount and remount so that the new default subvol is used
-	umount -R /sysroot
-	# Manual umount confuses systemd sometimes because it's async and the
-	# .mount unit might still be active when the "start" is queued, making
-	# it a noop, which ultimately leaves /sysroot unmounted
-	# (https://github.com/systemd/systemd/issues/20329). To avoid that,
-	# wait until systemd processed the umount events. In a chroot (or with
-	# SYSTEMD_OFFLINE=1) systemctl always succeeds, so avoid an infinite loop.
-	if ! systemctl --quiet is-active does-not-exist.mount; then
-		while systemctl --quiet is-active sysroot.mount; do sleep 0.5; done
+	if findmnt /sysroot >/dev/null; then
+		# umount and remount so that the new default subvol is used
+		umount -R /sysroot
+		# Manual umount confuses systemd sometimes because it's async and the
+		# .mount unit might still be active when the "start" is queued, making
+		# it a noop, which ultimately leaves /sysroot unmounted
+		# (https://github.com/systemd/systemd/issues/20329). To avoid that,
+		# wait until systemd processed the umount events. In a chroot (or with
+		# SYSTEMD_OFFLINE=1) systemctl always succeeds, so avoid an infinite loop.
+		if ! systemctl --quiet is-active does-not-exist.mount; then
+			while systemctl --quiet is-active sysroot.mount; do sleep 0.5; done
+		fi
 	fi
 	systemctl start sysroot.mount
 }


### PR DESCRIPTION
If /sysroot was not mounted previously (like by ignition-mount.service) and no config was provided, combustion would not start sysroot.mount but attempt to unmount it during exit, causing a fatal error.

Just skip the unmount during cleanup if it's not mounted.