### PR TITLE
Try the KIWI selfinstall .iso as fallback config source

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ How to use it
 The configuration files are copied from a filesystem with the LABEL
 "combustion", but to be compatible and co-installable with ignition
 (https://github.com/coreos/ignition), the LABEL "ignition" is used as fallback.
-All-uppercase labels are accepted as well.
+All-uppercase labels are accepted as well. Alternatively, if a KIWI selfinstall
+.iso is used for deployment (LABEL "INSTALL"), this is used as a fallback.
+
 It expects a directory "combustion" at the root level of the filesystem and
 a file "script" inside, which is executed inside a transactional-update shell.
 

--- a/combustion
+++ b/combustion
@@ -24,7 +24,8 @@ if [ "${1-}" = "--prepare" ]; then
 	fi
 
 	# Try disks next - both lower and upper case
-	for label in combustion COMBUSTION ignition IGNITION; do
+	# "INSTALL" is used as label for KIWI selfinstall .isos. Try those as fallback.
+	for label in combustion COMBUSTION ignition IGNITION install INSTALL; do
 		[ -d "${config_dir}" ] && break
 		[ -e "/dev/disk/by-label/${label}" ] || continue
 

--- a/combustion.rules
+++ b/combustion.rules
@@ -10,6 +10,10 @@ ACTION=="add", SUBSYSTEM=="block", ENV{ID_FS_LABEL}=="combustion", ENV{SYSTEMD_A
 ACTION=="add", SUBSYSTEM=="block", ENV{ID_FS_LABEL}=="COMBUSTION", ENV{SYSTEMD_ALIAS}+="/dev/combustion/config"
 ACTION=="add", SUBSYSTEM=="block", ENV{ID_FS_LABEL}=="ignition", ENV{SYSTEMD_ALIAS}+="/dev/combustion/config"
 ACTION=="add", SUBSYSTEM=="block", ENV{ID_FS_LABEL}=="IGNITION", ENV{SYSTEMD_ALIAS}+="/dev/combustion/config"
+# These can be used as config source as well, but they cannot be used as providers for
+# /dev/combustion/config, as some other config source with higher priority might show up later.
+#ACTION=="add", SUBSYSTEM=="block", ENV{ID_FS_LABEL}=="install", ENV{SYSTEMD_ALIAS}+="/dev/combustion/config"
+#ACTION=="add", SUBSYSTEM=="block", ENV{ID_FS_LABEL}=="INSTALL", ENV{SYSTEMD_ALIAS}+="/dev/combustion/config"
 # QEMU fw_cfg blob with key opt/org.opensuse.combustion
 # There are add events for keys inside fw_cfg, but they are unreliable: https://github.com/systemd/systemd/issues/28638
 # Using the platform device with add|bind does not work with TAG+="systemd" for some reason, so use the module...


### PR DESCRIPTION
Using xorriso it's possible to put configuration into the .iso and use a single drive for installation.