### PR TITLE
WIP: Run combustion in a private mount namespace

### DIFF
--- a/combustion
+++ b/combustion
@@ -108,6 +108,18 @@ if [ "${1-}" = "--complete" ]; then
 	complete=1
 fi
 
+# Create a mount namespace. This does some manual mounts which might confuse systemd otherwise.
+# In the future, when combustion is not called explicitly from ignition, replace this with:
+# PrivateMounts=true
+# TemporaryFileSystem=/run/mount
+if [ -z "${MNT_UNSHARED-}" ]; then
+	MNT_UNSHARED=1 exec unshare -m --propagation slave "$0" "$@"
+fi
+unset MNT_UNSHARED
+# Work around https://github.com/systemd/systemd/issues/28723
+mkdir -p /run/mount
+mount -t tmpfs tmpfs /run/mount
+
 delete_resolv_conf=0
 
 cleanup() {
@@ -117,20 +129,7 @@ cleanup() {
         	rm -f /sysroot/etc/resolv.conf || true
 	fi
 
-	if findmnt /sysroot >/dev/null; then
-		# umount and remount so that the new default subvol is used
-		umount -R /sysroot
-		# Manual umount confuses systemd sometimes because it's async and the
-		# .mount unit might still be active when the "start" is queued, making
-		# it a noop, which ultimately leaves /sysroot unmounted
-		# (https://github.com/systemd/systemd/issues/20329). To avoid that,
-		# wait until systemd processed the umount events. In a chroot (or with
-		# SYSTEMD_OFFLINE=1) systemctl always succeeds, so avoid an infinite loop.
-		if ! systemctl --quiet is-active does-not-exist.mount; then
-			while systemctl --quiet is-active sysroot.mount; do sleep 0.5; done
-		fi
-	fi
-	systemctl start sysroot.mount
+	# This runs in a private mount namespace so unmounting is not necessary
 }
 
 # Note: The /sysroot remounting during cleanup happens unconditionally.
@@ -140,6 +139,12 @@ trap cleanup EXIT
 # Compatibility for ignition-kargs-helper, which drops a script into
 # "/run/combustion/mount/combustion" and then calls combustion
 if [ -d "${config_mount}/combustion" ]; then
+	# It also mounted /sysroot itself
+	if findmnt /sysroot >/dev/null; then
+		umount -R /sysroot
+	fi
+	# And set SYSTEMD_OFFLINE=1...
+	unset SYSTEMD_OFFLINE
 	rm -rf "${config_dir}"
 	mkdir -p "${exchangedir}"
 	cp -R "${config_mount}/combustion" "${config_dir}"
@@ -148,12 +153,15 @@ fi
 
 [ -d "${config_dir}" ] || exit 0
 
-# Make sure /sysroot is mounted
-systemctl start sysroot.mount
+what=$(systemctl show -P What sysroot.mount)
+opts=$(systemctl show -P Options sysroot.mount)
+mount -o "$opts" "$what" /sysroot
 
 # Same for /sysroot/usr if it exists (e.g. through mount.usr)
 if systemctl cat sysroot-usr.mount &>/dev/null; then
-	systemctl start sysroot-usr.mount
+	what=$(systemctl show -P What sysroot-usr.mount)
+	opts=$(systemctl show -P Options sysroot-usr.mount)
+	mount -o "$opts" "$what" /sysroot/usr
 fi
 
 # Have to take care of x-initrd.mount first and from the outside.
@@ -172,7 +180,6 @@ fi
 for i in proc sys dev; do
 	mount --rbind /$i /sysroot/$i
 done
-mount --make-rslave /sysroot
 
 # Mount everything we can, errors deliberately ignored
 chroot /sysroot mount -a || true

--- a/combustion.service
+++ b/combustion.service
@@ -2,10 +2,11 @@
 Description=Combustion
 DefaultDependencies=false
 
-# /sysroot needs to be available, but it's temporarily stopped
-# for remounting so a direct requirement is not possible
+# This changes the default subvol so has to run before /sysroot,
+# but /sysroot has to be mountable.
+Before=sysroot.mount
 Requires=initrd-root-device.target
-After=initrd-root-device.target
+After=initrd-root-device.target systemd-fsck-root.service
 
 # combustion-prepare sets up network, if required
 Requires=combustion-prepare.service
@@ -14,11 +15,10 @@ After=combustion-prepare.service
 # Optionally make network available
 After=network.target
 
-# After ignition completed its stuff
-After=ignition-complete.target
-
-# So that /etc/fstab's x-initrd.mount entries are read (again) later
-Before=initrd-parse-etc.service
+# This runs in between ignition stages which don't need /sysroot
+# and stages which do. ignition-kargs might trigger a reboot, so
+# order after that to avoid running combustion twice.
+After=ignition-kargs.service
 
 # Without DefaultDependencies the target would be reached without us
 Before=firstboot.target

--- a/module-setup.sh
+++ b/module-setup.sh
@@ -15,18 +15,12 @@ install() {
 	inst_simple "${moddir}/combustion-prepare.service" "${systemdsystemunitdir}/combustion-prepare.service"
 	inst_simple "${moddir}/combustion.rules" "/etc/udev/rules.d/70-combustion.rules"
 	$SYSTEMCTL -q --root "$initdir" enable combustion.service
-	inst_multiple awk chroot findmnt grep rmdir
+	inst_multiple awk chroot findmnt grep rmdir unshare
 	inst_simple "${moddir}/combustion" "/usr/bin/combustion"
 
 	# Autodetect dasd devices on s390x to discover the config drive
 	mkdir -p "${initdir}/etc/modprobe.d"
 	echo "options dasd_mod dasd=autodetect" > "${initdir}/etc/modprobe.d/dasd-autodetect.conf"
-
-	# ignition-mount.service mounts stuff below /sysroot in ExecStart and umounts
-	# it on ExecStop, failing if umounting fails. This conflicts with the
-	# mounts/umounts done by combustion. Just let combustion do it instead.
-	mkdir -p "${initdir}/${systemdsystemunitdir}/ignition-mount.service.d/"
-	echo -e "[Service]\nExecStop=" > "${initdir}/${systemdsystemunitdir}/ignition-mount.service.d/noexecstop.conf"
 
 	# Wait up to 10s (30s on aarch64) for the config drive
 	devtimeout=10


### PR DESCRIPTION
This avoids the need for some hacks and should make it more reliable.

Doing this in combustion.service would be nice but that breaks calling combustion explicitly, like done by ignition and for debugging in the emergency shell.