### PR TITLE
Only enable all existing DASDs if it's actually the first boot (bsc#1…

### DIFF
--- a/30firstboot/firstboot-detect
+++ b/30firstboot/firstboot-detect
@@ -18,6 +18,12 @@ awk '$1 !~ /^#/ && $4 ~ /(\<|,)x-initrd\.mount(\>|,)/ { if(system("mount --targe
 if ! [ -e /sysroot/etc/machine-id ] \
 	|| grep -qw 'ignition\.firstboot' /proc/cmdline || grep -qw 'combustion\.firstboot' /proc/cmdline; then
 	echo "Firstboot detected"
+	if [ "$(uname -m)" = "s390x" ]; then
+		# On s390x, attached DASDs need to be enabled first to appear as block devices.
+		# On the first boot this is necessary to probe for configuration sources.
+		echo "Trying to enable all available DASDs"
+		chzdev dasd --offline --existing --enable --active || echo "Couldn't enable all devices, trying to continue anyway." >&2
+	fi
 	# Make initrd.target require firstboot.target
 	systemctl enable --quiet firstboot.target
 	# As initrd.target/start was already scheduled, ^ does not have any immediate effect.

--- a/30firstboot/module-setup.sh
+++ b/30firstboot/module-setup.sh
@@ -14,6 +14,17 @@ install() {
 	$SYSTEMCTL -q --root "$initdir" enable firstboot-detect.service
 	inst_multiple awk grep mount
 
+	if [ "${DRACUT_ARCH:-$(uname -m)}" = "s390x" ]; then
+		# Special behaviour on s390x: On the first boot, enable all DASDs
+		inst_multiple chzdev
+
+		# On all boots, enable at least the IPL dev.
+		# Once the initrd was rebuilt without this module, it should contain
+		# an appropriate rd.dasd parameter instead to trigger enabling.
+		mkdir -p "${initdir}/etc/modprobe.d"
+		echo "options dasd_mod dasd=ipldev" > "${initdir}/etc/modprobe.d/dasd-ipldev.conf"
+	fi
+
 	# Work around https://github.com/systemd/systemd/pull/28718
 	mkdir -p "${initdir}/${systemdsystemunitdir}/initrd-parse-etc.service.d/"
 	echo -e "[Unit]\nConflicts=emergency.target" > "${initdir}/${systemdsystemunitdir}/initrd-parse-etc.service.d/emergency.conf"

--- a/module-setup.sh
+++ b/module-setup.sh
@@ -19,10 +19,6 @@ install() {
 	inst_multiple -o base64 gzip vmware-rpctool
 	inst_simple "${moddir}/combustion" "/usr/bin/combustion"
 
-	# Autodetect dasd devices on s390x to discover the config drive
-	mkdir -p "${initdir}/etc/modprobe.d"
-	echo "options dasd_mod dasd=autodetect" > "${initdir}/etc/modprobe.d/dasd-autodetect.conf"
-
 	# ignition-mount.service mounts stuff below /sysroot in ExecStart and umounts
 	# it on ExecStop, failing if umounting fails. This conflicts with the
 	# mounts/umounts done by combustion. Just let combustion do it instead.


### PR DESCRIPTION
Specify ipldev in the other cases.

Currently this breaks booting because of https://bugzilla.suse.com/show_bug.cgi?id=1220712