### PR TITLE
30firstboot: Leave IPL DASD enablement to s390-tools (jsc#PED-8130)

### DIFF
--- a/30firstboot/firstboot-detect
+++ b/30firstboot/firstboot-detect
@@ -22,7 +22,7 @@ if ! [ -e /sysroot/etc/machine-id ] \
 		# On s390x, attached DASDs need to be enabled first to appear as block devices.
 		# On the first boot this is necessary to probe for configuration sources.
 		echo "Trying to enable all available DASDs"
-		chzdev dasd --offline --existing --enable --active || echo "Couldn't enable all devices, trying to continue anyway." >&2
+		chzdev dasd --offline --existing --enable --active || echo "Couldn't enable all DASD devices, trying to continue anyway." >&2
 	fi
 	# Make initrd.target require firstboot.target
 	systemctl enable --quiet firstboot.target

--- a/30firstboot/module-setup.sh
+++ b/30firstboot/module-setup.sh
@@ -17,12 +17,6 @@ install() {
 	if [ "${DRACUT_ARCH:-$(uname -m)}" = "s390x" ]; then
 		# Special behaviour on s390x: On the first boot, enable all DASDs
 		inst_multiple chzdev
-
-		# On all boots, enable at least the IPL dev.
-		# Once the initrd was rebuilt without this module, it should contain
-		# an appropriate rd.dasd parameter instead to trigger enabling.
-		mkdir -p "${initdir}/etc/modprobe.d"
-		echo "options dasd_mod dasd=ipldev" > "${initdir}/etc/modprobe.d/dasd-ipldev.conf"
 	fi
 
 	# Work around https://github.com/systemd/systemd/pull/28718


### PR DESCRIPTION
Setting dasd_mod.dasd=ipldev prevents module loading if the IPL device is not a DASD, so it can only be done conditionally.

This must not be merged before s390-tools performs equivalent initialization.