### PR TITLE
Start transactional-update in a PID namespace

### DIFF
--- a/combustion
+++ b/combustion
@@ -259,7 +259,9 @@ fi
 if [ -x /sysroot/usr/sbin/transactional-update ]; then
 	# t-u doesn't allow running arbitrary commands and
 	# also ignores the shell's exit code, so DIY.
-	if ! chroot /sysroot transactional-update shell <<EOF; then
+	# Use unshare with a PID namespace to make sure no daemonized processes
+	# like gpg-agent (triggered by zypper) stay running and keep /sysroot busy.
+	if ! unshare -p --mount-proc --kill-child -R /sysroot transactional-update shell <<EOF; then
 		cd "${config_dir}"
 		./script
 		echo \$? > "${exchangedir}/retval"

--- a/module-setup.sh
+++ b/module-setup.sh
@@ -15,7 +15,7 @@ install() {
 	inst_simple "${moddir}/combustion-prepare.service" "${systemdsystemunitdir}/combustion-prepare.service"
 	inst_simple "${moddir}/combustion.rules" "/etc/udev/rules.d/70-combustion.rules"
 	$SYSTEMCTL -q --root "$initdir" enable combustion.service
-	inst_multiple awk chroot findmnt grep rmdir systemd-detect-virt wc
+	inst_multiple awk chroot findmnt grep rmdir systemd-detect-virt unshare wc
 	inst_multiple -o base64 gzip vmware-rpctool
 	inst_simple "${moddir}/combustion" "/usr/bin/combustion"
 


### PR DESCRIPTION
This makes sure that no processes stay running after the transaction got closed, avoiding that umount /sysroot fails with EBUSY.

Not sure whether this is a good idea: PID1 isn't systemd anymore.