### PR TITLE
Stop gpg-agent before umounting /sysroot

### DIFF
--- a/combustion
+++ b/combustion
@@ -152,6 +152,11 @@ cleanup() {
 	fi
 
 	if findmnt /sysroot >/dev/null; then
+		# zypper (both from t-u's selfupdate as well as the script)
+		# uses gpg which starts gpg-agent in the background. This keeps
+		# /sysroot busy, so we'll have to stop those.
+		while pkill -x gpg-agent; do sleep 0.5; done
+
 		# umount and remount so that the new default subvol is used
 		umount -R /sysroot
 		# Manual umount confuses systemd sometimes because it's async and the

--- a/module-setup.sh
+++ b/module-setup.sh
@@ -15,7 +15,7 @@ install() {
 	inst_simple "${moddir}/combustion-prepare.service" "${systemdsystemunitdir}/combustion-prepare.service"
 	inst_simple "${moddir}/combustion.rules" "/etc/udev/rules.d/70-combustion.rules"
 	$SYSTEMCTL -q --root "$initdir" enable combustion.service
-	inst_multiple awk chroot findmnt grep rmdir systemd-detect-virt wc
+	inst_multiple awk chroot findmnt grep pkill rmdir systemd-detect-virt wc
 	inst_multiple -o base64 gzip vmware-rpctool
 	inst_simple "${moddir}/combustion" "/usr/bin/combustion"
 


### PR DESCRIPTION
gpg starts that from inside /sysroot, preventing the umount from working sometimes.