### PR TITLE
Avoid misleading "Application returned with exit status 1" message

### DIFF
--- a/combustion
+++ b/combustion
@@ -170,6 +170,11 @@ cleanup() {
 			while systemctl --quiet is-active sysroot.mount; do sleep 0.5; done
 		fi
 	fi
+
+	if grep -w /sysroot /proc/*/mountinfo; then
+		echo "Warning: /sysroot still mounted somewhere"
+	fi
+
 	systemctl start sysroot.mount
 }
 

--- a/combustion
+++ b/combustion
@@ -279,7 +279,7 @@ if [ -x /sysroot/usr/sbin/transactional-update ]; then
 		./script
 		echo \$? > "${exchangedir}/retval"
 		# Snapshot got touched while the policy isn't active, needs relabeling again.
-		[ -e /etc/selinux/.relabelled ] && >> /etc/selinux/.autorelabel
+		if [ -e /etc/selinux/.relabelled ]; then >> /etc/selinux/.autorelabel; fi
 EOF
 		echo "transactional-update failed"
 		exit 1

--- a/combustion
+++ b/combustion
@@ -219,13 +219,6 @@ if systemctl cat sysroot-usr.mount &>/dev/null; then
 	systemctl start sysroot-usr.mount
 fi
 
-# Care needs to be taken that umount -R /sysroot later works as expected,
-# taking mount propagation and other processes in private mount namespaces into account.
-# Ideally combustion runs in its own mount namespace, but the needed redesign breaks
-# some subtle interactions with the outside.
-# Make /sysroot private so that the next mounts are not visible in other namespaces.
-mount --make-private /sysroot
-
 # Have to take care of x-initrd.mount first and from the outside.
 # Note: ignition-kargs-helper calls combustion but already mounted those itself.
 awk '$1 !~ /^#/ && $4 ~ /(\<|,)x-initrd\.mount(\>|,)/ { if(system("findmnt /sysroot/" $2 " >/dev/null || mount --target-prefix /sysroot --fstab /sysroot/etc/fstab " $2) != 0) exit 1; }' /sysroot/etc/fstab
@@ -243,10 +236,21 @@ awk '$1 !~ /^#/ && $4 ~ /(\<|,)x-initrd\.mount(\>|,)/ { if(system("findmnt /sysr
 	fi
 )
 
-# Prepare chroot
-for i in proc sys dev; do
-	# Make these rslave so that unmounting does not affect the real /$i
-	mount --make-rslave --rbind /$i /sysroot/$i
+# Prepare chroot.
+# Ideally this would just be --rbind /dev /sysroot/dev etc., but that has subtle downsides:
+# By default, umount -R /sysroot would then propagate into the main /dev etc. and try to
+# unmount /dev/shm/ etc. which must be avoided. Disabling mount propagation with
+# --make-rslave interacts badly with other mount namespaces (used for PrivateMounts=true
+# e.g. by systemd-udevd.service): The mounts propagate, but not all unmounts, leaving e.g.
+# /sysroot/dev/shm/ mounted in udev's mnt context. To avoid all that, just bind mount
+# everything individually, then it can be unmounted without caring about propagation.
+# Alternatives are
+# a) mount --bind --make-private /sysroot /sysroot on itself, but then e.g. udev doesn't
+#    see the same /sysroot as us
+# b) Run combustion in its own mount namespace, but the needed redesign breaks some
+#    subtle interactions with the outside.
+findmnt -nrvo TARGET | grep -E '^/(sys|proc|dev)(/|$)' | while read i; do
+	mount --bind "$i" "/sysroot/$i"
 done
 
 # Mount everything we can, errors deliberately ignored

--- a/test/config.ign
+++ b/test/config.ign
@@ -1,0 +1,18 @@
+{
+  "ignition": {
+    "version": "3.2.0"
+  },
+  "storage": {
+    "filesystems": [
+      {
+        "device": "/dev/disk/by-label/ROOT",
+        "format": "btrfs",
+        "mountOptions": [
+          "subvol=/@/home"
+        ],
+        "path": "/home",
+        "wipeFilesystem": false
+      }
+    ]
+  }
+}

--- a/test/test.sh
+++ b/test/test.sh
@@ -37,7 +37,7 @@ QEMU_BASEARGS=(
 # Prepare the temporary dir: Install combustion and copy resources.
 testdir="$(dirname "$0")"
 make -C "${testdir}/.." install "DESTDIR=${tmpdir}/install"
-cp "${testdir}/testscript" "${tmpdir}"
+cp "${testdir}/"{testscript,config.ign} "${tmpdir}"
 cd "$tmpdir"
 
 # Download latest MicroOS image
@@ -82,7 +82,9 @@ qemu-img snapshot -a initial openSUSE-MicroOS.x86_64-kvm-and-xen.qcow2
 
 mkdir -p configdrv/combustion/
 cp testscript configdrv/combustion/script
-/sbin/mkfs.ext4 -F -d configdrv -L IGNITION combustion.raw 16M
+mkdir -p configdrv/ignition/
+cp config.ign configdrv/ignition/config.ign
+/sbin/mkfs.ext4 -F -d configdrv -L ignition combustion.raw 16M
 
 timeout 300 qemu-system-x86_64 "${QEMU_BASEARGS[@]}" -drive if=virtio,file=openSUSE-MicroOS.x86_64-kvm-and-xen.qcow2 \
 	-kernel vmlinuz -initrd initrd -append "root=LABEL=ROOT console=ttyS0 quiet systemd.show_status=1 systemd.log_target=console systemd.journald.forward_to_console=1 rd.emergency=poweroff rd.shell=0" \

--- a/test/testscript
+++ b/test/testscript
@@ -27,6 +27,9 @@ cat >>/usr/bin/combustion-validate <<'EOF'
 set -euxo pipefail
 exec &>/dev/ttyS0
 trap '[ $? -eq 0 ] || poweroff -f' EXIT
+if journalctl --no-pager | grep "/sysroot still mounted somewhere"; then
+    exit 1
+fi
 mount -t 9p -o trans=virtio tmpdir /mnt
 touch /mnt/done
 umount /mnt


### PR DESCRIPTION
Using a short-circuit conditional as last instruction inside the t-u shell
causes the exit status to be 1 even if nothing went wrong. Use a full if
instead.