### PR TITLE
Log combustion-prepare.service to journal+console

### DIFF
--- a/combustion-prepare.service
+++ b/combustion-prepare.service
@@ -24,4 +24,5 @@ Conflicts=dracut-emergency.service emergency.service emergency.target
 
 [Service]
 Type=oneshot
+StandardOutput=journal+console
 ExecStart=/usr/bin/combustion --prepare


### PR DESCRIPTION
The usual trick of using tee to make the output visible to the user directly doesn't work in the prepare phase because tee is not available. Just write all output to the console as well.