### PR TITLE
Silence stderr of grep in /proc/*/mountinfo

### DIFF
--- a/combustion
+++ b/combustion
@@ -171,7 +171,7 @@ cleanup() {
 		fi
 	fi
 
-	if grep -w /sysroot /proc/*/mountinfo; then
+	if grep -w /sysroot /proc/*/mountinfo 2>/dev/null; then
 		echo "Warning: /sysroot still mounted somewhere"
 	fi
 


### PR DESCRIPTION
If processes die in between readdir and open it's possible that grep gets an ENOENT and writes an error to stderr. Avoid that.