### PR TITLE
Drop wicked to be able to run firstboot-detect.service after initqueue

### DIFF
--- a/30firstboot/firstboot-detect.service
+++ b/30firstboot/firstboot-detect.service
@@ -7,17 +7,14 @@ DefaultDependencies=no
 ConditionKernelCommandLine=!initgrub
 
 # This needs /sysroot to be mountable
-# Should also include systemd-fsck-root, but that would create a cycle
-# with dracut-initqueue below.
-Requires=initrd-root-device.target
-After=initrd-root-device.target
+Requires=systemd-fsck-root.service
+After=systemd-fsck-root.service
 
 # But before it's actually mounted
 Before=sysroot.mount
 
-# Combustion/ignition may configure networking, which runs during
-# the initqueue (wicked) or has its own service (NM)
-Before=dracut-initqueue.service nm-initrd.service
+# Combustion/ignition may configure networking, so run before nm-initrd.service.
+Before=nm-initrd.service
 
 # Make sure this is stopped before switch root or emergency:
 # https://github.com/systemd/systemd/issues/3436

--- a/combustion
+++ b/combustion
@@ -22,13 +22,7 @@ if [ "${1-}" = "--prepare" ]; then
 			# Set rd.neednet if not already done and reevaluate it (module-specific)
 			getargbool 0 'rd.neednet' && exit 0
 			echo rd.neednet=1 > /etc/cmdline.d/40-combustion-neednet.conf
-			if [ -e "${hookdir}/pre-udev/60-net-genrules.sh" ]; then
-				# Wicked
-				. "${hookdir}/pre-udev/60-net-genrules.sh"
-				# Re-trigger generation of network rules and apply them
-				udevadm control --reload
-				udevadm trigger --subsystem-match net --action add
-			elif [ -e "${hookdir}/cmdline/99-nm-config.sh" ]; then
+			if [ -e "${hookdir}/cmdline/99-nm-config.sh" ]; then
 				# NetworkManager
 				. "${hookdir}/cmdline/99-nm-config.sh"
 			else

--- a/combustion.service
+++ b/combustion.service
@@ -12,7 +12,8 @@ Requires=combustion-prepare.service
 After=combustion-prepare.service
 
 # Optionally make network available
-After=network.target
+Wants=network-online.target
+After=network-online.target
 
 # After ignition completed its stuff
 After=ignition-complete.target


### PR DESCRIPTION
Some setups like / on LVM need initqueue to get the root device. This conflicts with wicked which performs network setup during initqueue, so drop support for wicked entirely.