### PR TITLE
Add support for nested /etc subvolumes

### DIFF
--- a/30firstboot/firstboot-detect
+++ b/30firstboot/firstboot-detect
@@ -13,7 +13,7 @@ fi
 mount -o "$opts" "$what" /sysroot
 
 # Handle x-initrd.mount without initrd-parse-etc.service
-awk '$1 !~ /^#/ && $4 ~ /(\<|,)x-initrd\.mount(\>|,)/ { if(system("mount --target-prefix /sysroot --fstab /sysroot/etc/fstab " $2) != 0) exit 1; }' /sysroot/etc/fstab
+awk '$1 !~ /^#/ && $4 ~ /(\<|,)x-initrd\.mount(\>|,)/ && ! ( $2 == "/etc" && $3 == "none" ) { if(system("mount --target-prefix /sysroot --fstab /sysroot/etc/fstab " $2) != 0) exit 1; }' /sysroot/etc/fstab
 
 if ! [ -e /sysroot/etc/machine-id ] \
 	|| grep -qw 'ignition\.firstboot' /proc/cmdline || grep -qw 'combustion\.firstboot' /proc/cmdline; then

--- a/combustion
+++ b/combustion
@@ -219,9 +219,10 @@ if systemctl cat sysroot-usr.mount &>/dev/null; then
 	systemctl start sysroot-usr.mount
 fi
 
-# Have to take care of x-initrd.mount first and from the outside.
+# Have to take care of x-initrd.mount first and from the outside, but skip /etc
+# if it's the new nested subvolume mechanism
 # Note: ignition-kargs-helper calls combustion but already mounted those itself.
-awk '$1 !~ /^#/ && $4 ~ /(\<|,)x-initrd\.mount(\>|,)/ { if(system("findmnt /sysroot/" $2 " >/dev/null || mount --target-prefix /sysroot --fstab /sysroot/etc/fstab " $2) != 0) exit 1; }' /sysroot/etc/fstab
+awk '$1 !~ /^#/ && $4 ~ /(\<|,)x-initrd\.mount(\>|,)/ && ! ( $2 == "/etc" && $3 == "none" ) { if(system("findmnt /sysroot/" $2 " >/dev/null || mount --target-prefix /sysroot --fstab /sysroot/etc/fstab " $2) != 0) exit 1; }' /sysroot/etc/fstab
 
 # Make sure the old snapshot is relabeled too, otherwise syncing its /etc fails.
 (


### PR DESCRIPTION
transactional-update 5.0.0 doesn't use overlayfs any more, so /etc would be available directly. For backward compatibility just skip the new bind mount though.