### PR TITLE
Restart NetworkManager-config-initrd.service after sourcing 99-nm-config.sh

### DIFF
--- a/combustion
+++ b/combustion
@@ -31,6 +31,9 @@ if [ "${1-}" = "--prepare" ]; then
 			elif [ -e "${hookdir}/cmdline/99-nm-config.sh" ]; then
 				# NetworkManager
 				. "${hookdir}/cmdline/99-nm-config.sh"
+				if [ -e /usr/lib/systemd/system/NetworkManager-config-initrd.service ]; then
+					systemctl restart NetworkManager-config-initrd.service
+				fi
 			else
 				echo "ERROR: unknown network framework" >&2
 				exit 1


### PR DESCRIPTION
Combustion sets `rd.neednet` in /etc/cmdline.d/40-combustion-neednet.conf after dracut's cmdline hooks run, so it manually sources network-manager's cmdline hook `${hookdir}/cmdline/99-nm-config.sh` to call nm-initrd-generator and generate connections. This is done now by NetworkManager-config-initrd.service.