### PR TITLE
Better compatibility with mkosi built images

### DIFF
--- a/30firstboot/firstboot-detect
+++ b/30firstboot/firstboot-detect
@@ -15,7 +15,7 @@ mount -o "$opts" "$what" /sysroot
 # Handle x-initrd.mount without initrd-parse-etc.service
 awk '$1 !~ /^#/ && $4 ~ /(\<|,)x-initrd\.mount(\>|,)/ && ! ( $2 == "/etc" && $3 == "none" ) { if(system("mount --target-prefix /sysroot --fstab /sysroot/etc/fstab " $2) != 0) exit 1; }' /sysroot/etc/fstab
 
-if ! [ -e /sysroot/etc/machine-id ] \
+if ! [ -e /sysroot/etc/machine-id ] || grep -qw uninitialized /sysroot/etc/machine-id \
 	|| grep -qw 'ignition\.firstboot' /proc/cmdline || grep -qw 'combustion\.firstboot' /proc/cmdline; then
 	echo "Firstboot detected"
 	if [ "$(uname -m)" = "s390x" ]; then

--- a/combustion
+++ b/combustion
@@ -263,10 +263,16 @@ chroot /sysroot mount -a || true
 findmnt /sysroot/run >/dev/null || mount -t tmpfs tmpfs /sysroot/run
 findmnt /sysroot/tmp >/dev/null || mount -t tmpfs tmpfs /sysroot/tmp
 
-# The /etc bind mount in the nested subvolume setup is read-only at first,
-# make it read-write.
+# Need to write to /sysroot/etc for possibly creating resolv.conf
+# and touching /etc/selinux/.autorelabel.
 if ! [ -w /sysroot/etc ]; then
-	mount -o remount,rw /sysroot/etc
+	# Transactional systems have a separate mount for /etc.
+	# In the nested subvolume setup there's a bind mount that is read-only at first.
+	if findmnt /sysroot/etc >/dev/null; then
+		mount -o remount,rw /sysroot/etc
+	else
+		mount -o remount,rw /sysroot
+	fi
 fi
 
 # Fake a netconfig setup
@@ -319,7 +325,6 @@ EOF
 		systemctl daemon-reload # Unfortunately required for this :-/
 	fi
 else
-	mount -o remount,rw /sysroot
 	if ! chroot /sysroot sh -e -c "cd '${config_dir}'; ./script"; then
 		echo "Command failed"
 		exit 1


### PR DESCRIPTION
It uses a more modern way of (not) initializing /etc/machine id and does not pass `rw` on the cmdline by default.