### PR TITLE
Write /etc/.combustion-result.json on completion

### DIFF
--- a/combustion
+++ b/combustion
@@ -334,6 +334,7 @@ fi
 
 if [ "${complete}" -eq 1 ]; then
 	rm -f /sysroot/var/lib/YaST2/reconfig_system
+	echo '{}' > /sysroot/etc/.combustion-result.json
 fi
 
 exit 0


### PR DESCRIPTION
- Write `/etc/.combustion-result.json` when running with `--complete`, consistent with ignition's `/etc/.ignition-result.json` pattern
- This allows `jeos-firstboot` to detect that combustion already configured the system and skip the firstboot wizard when `ConditionFirstBoot=|yes` is used as an alternative trigger

## Context

When `jeos-firstboot` adds `ConditionFirstBoot=|yes` support (openSUSE/jeos-firstboot#98, openSUSE/jeos-firstboot#136), deleting `/var/lib/YaST2/reconfig_system` alone is no longer sufficient to suppress the firstboot wizard, since `ConditionFirstBoot` will still be true on first boot (machine-id is uninitialized).

The marker file approach was suggested in openSUSE/jeos-firstboot#136.

Fixes #46
